### PR TITLE
FEAT/#8 예외처리

### DIFF
--- a/src/main/java/com/fluffy/SharingCalendar/exception/CustomException.java
+++ b/src/main/java/com/fluffy/SharingCalendar/exception/CustomException.java
@@ -1,0 +1,10 @@
+package com.fluffy.SharingCalendar.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/fluffy/SharingCalendar/exception/ErrorCode.java
+++ b/src/main/java/com/fluffy/SharingCalendar/exception/ErrorCode.java
@@ -1,0 +1,28 @@
+package com.fluffy.SharingCalendar.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode {
+    /* 400 BAD_REQUEST 잘못된 요청 */
+    INVALID_PARAMETER(BAD_REQUEST, "파라미터 값을 확인해주세요."),
+
+    /* 404 NOT_FOUND 잘못된 리소스 접근 */
+    CALENDAR_NOT_FOUND(NOT_FOUND, "해당 캘린더를 찾을 수 없습니다."),
+
+    /* 409 CONFLICT 중복된 리소스 */
+    ALREADY_SAVED_DISPLAY(CONFLICT, "이미 존재하는 닉네임입니다."),
+
+    /* 500 INTERNAL SERVER ERROR */
+    UNSUCCESSFUL_UPLOAD(INTERNAL_SERVER_ERROR, "이미지 파일 업로드에 실패했습니다."),
+    SERVER_ERROR(INTERNAL_SERVER_ERROR, "서버 에러입니다. 관리자 이메일로 연락주세요!");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}
+

--- a/src/main/java/com/fluffy/SharingCalendar/exception/ErrorResponse.java
+++ b/src/main/java/com/fluffy/SharingCalendar/exception/ErrorResponse.java
@@ -1,7 +1,7 @@
 package com.fluffy.SharingCalendar.exception;
 
 public record ErrorResponse(Integer errorCode, String message) {
-    public static ErrorResponse toErrorResponse(ErrorCode errorCode) {
+    public static ErrorResponse from(ErrorCode errorCode) {
         return new ErrorResponse(errorCode.getHttpStatus().value(), errorCode.getMessage());
     }
 }

--- a/src/main/java/com/fluffy/SharingCalendar/exception/ErrorResponse.java
+++ b/src/main/java/com/fluffy/SharingCalendar/exception/ErrorResponse.java
@@ -1,12 +1,5 @@
 package com.fluffy.SharingCalendar.exception;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-
-@Getter
-@EqualsAndHashCode
-@AllArgsConstructor
 public record ErrorResponse(Integer errorCode, String message) {
     public static ErrorResponse toErrorResponse(ErrorCode errorCode) {
         return new ErrorResponse(errorCode.getHttpStatus().value(), errorCode.getMessage());

--- a/src/main/java/com/fluffy/SharingCalendar/exception/ErrorResponse.java
+++ b/src/main/java/com/fluffy/SharingCalendar/exception/ErrorResponse.java
@@ -1,0 +1,14 @@
+package com.fluffy.SharingCalendar.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+@AllArgsConstructor
+public record ErrorResponse(Integer errorCode, String message) {
+    public static ErrorResponse toErrorResponse(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getHttpStatus().value(), errorCode.getMessage());
+    }
+}

--- a/src/main/java/com/fluffy/SharingCalendar/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/fluffy/SharingCalendar/exception/GlobalExceptionHandler.java
@@ -15,7 +15,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponse> handleCustomException(CustomException ex) {
         log.error("=======CustomException=======", ex);
         ErrorCode errorCode = ex.getErrorCode();
-        return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.toErrorResponse(errorCode));
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.from(errorCode));
     }
 
     @ExceptionHandler(MissingServletRequestPartException.class)

--- a/src/main/java/com/fluffy/SharingCalendar/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/fluffy/SharingCalendar/exception/GlobalExceptionHandler.java
@@ -1,0 +1,33 @@
+package com.fluffy.SharingCalendar.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(value = CustomException.class)
+    protected ResponseEntity<ErrorResponse> handleCustomException(CustomException ex) {
+        log.error("=======CustomException=======", ex);
+        ErrorCode errorCode = ex.getErrorCode();
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.toErrorResponse(errorCode));
+    }
+
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    protected ResponseEntity<ErrorResponse> handleMissingServletRequestPartException(MissingServletRequestPartException ex) {
+        ErrorResponse response = new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage());
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    @ExceptionHandler({Exception.class, RuntimeException.class})
+    protected ResponseEntity<ErrorResponse> catchException(RuntimeException ex) {
+        log.error("========예외========", ex);
+        ErrorResponse response = new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage());
+        return ResponseEntity.internalServerError().body(response);
+    }
+}


### PR DESCRIPTION
예외 처리 관련 코드를 작성하였습니다! 🎉
이제부터 예외가 발생할 경우, ErrorCode에 정의된 에러 코드와 메시지를 활용하거나 추가하여 처리할 수 있습니다. 예를 들어, 아래와 같이 잘못된 파라미터에 대한 예외를 발생시킬 때는:

throw new CustomException(INVALID_PARAMETER);
이와 같이, CustomException을 통해 명시적으로 예외를 던지면, GlobalExceptionHandler에서 이를 감지하여 적절한 응답을 반환합니다. 에러 응답은 ErrorResponse로 형식화되어 클라이언트에게 전달되며, 이를 통해 더욱 명확하고 일관성 있는 예외 처리가 가능합니다. 😊